### PR TITLE
error fix patch (Oct21)

### DIFF
--- a/include/chessai.h
+++ b/include/chessai.h
@@ -42,7 +42,7 @@ private:
     std::vector<double> getStateRepresentation(); 
     Action actionToMove(const Action& action);
     Action moveToAction(int fromRow, int fromCol, int toRow, int toCol);
-    int evaluateBoard(PieceColor color);
+    int evaluateBoard(PieceColor color, int moveCount);
     
     // Learning parameters
     double learningRate = 0.001;

--- a/include/chessai.h
+++ b/include/chessai.h
@@ -25,6 +25,7 @@ public:
     void loadModel(const QString& filename);
 	void onGameCompleted(int gameNumber, int redScore, int blackScore);
 	void initializeDQN();
+	bool isDQNInitialized() const{ return dqn != nullptr;}
 
 public slots:
     void train(int numEpisodes);

--- a/include/chessboard.h
+++ b/include/chessboard.h
@@ -60,9 +60,8 @@ private:
     static constexpr int COLS = 9;
     QVector<ChessPiece> board; // Flat vector representing the board
     int moveCount{0};
+	int maxMovePerGame{200};
     PieceColor currentPlayer{PieceColor::Red};
-    bool isGeneralAlive(PieceColor color) const;
-
     bool isInRedPalace(int row, int col) const {
         return row >= 0 && row <= 2 && col >= 3 && col <= 5;
     }

--- a/src/chessboard.cpp
+++ b/src/chessboard.cpp
@@ -287,6 +287,10 @@ bool ChessBoard::checkGameOver() const {
     bool redGeneralAlive = false;
     bool blackGeneralAlive = false;
 
+	if(moveCount >= maxMovePerGame){
+		return true;
+	}
+
     for (int i = 0; i < ROWS * COLS; ++i) {
         const ChessPiece& piece = board[i];
         if (piece.type == PieceType::General) {

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -615,7 +615,9 @@ void MainWindow::trainAI()
         // Logic: Reset training visuals
         redScoreSeries->clear();
         blackScoreSeries->clear();
+        trainingProgressBar->setRange(0, numGames);
         trainingProgressBar->setValue(0);
+        trainingProgressBar->setFormat("Training Progress: %p%");
         QMessageBox::information(this, tr("Training Started"),
                                  tr("AI training started. This may take a while."));
         axisX->setMin(0);
@@ -825,6 +827,7 @@ void MainWindow::updateTrainingChart(int gameNumber, int redScore, int blackScor
 	    redScoreSeries->append(gameNumber, redScore);
 	    blackScoreSeries->append(gameNumber, blackScore);
 		trainingProgressBar->setValue(gameNumber);
+		trainingProgressBar->setFormat(QString("Training Progress: %1/%2 (%p%)").arg(gameNumber).arg(numGames));
 
 	    if (gameNumber > axisX->max()) {
 	        axisX->setMax(gameNumber + numGames * 0.1); // Increase range by 10%
@@ -905,3 +908,5 @@ void MainWindow::loadTrainedAI(){
                                  tr("AI model loaded successfully."));
     }	
 }
+
+


### PR DESCRIPTION
1. [Error Fix]: previously, the chessAI instance only exists while running AI training, which causes `nullptr` error in AI game mode without training.
2. [Error Fix] progress bar not sync with real progress
3. [Error Fix] DQN loadModel was using `std` file stream, while saveModel using `QDataStream`
4. [Bug Fix] without considering moveCount, in some scenarios, AI vs AI is stuck in a local minima loop raising infinite moves.